### PR TITLE
My first set of patches

### DIFF
--- a/microprint/TFPCLIController.m
+++ b/microprint/TFPCLIController.m
@@ -105,8 +105,10 @@
 			TFLog(@"No connected printer found!");
 			exit(EXIT_FAILURE);
 		}
+        			TFLog(@"M3D printer found!");
 		
 		[weakSelf.printer establishConnectionWithCompletionHandler:^(NSError *error) {
+            	TFLog(@"M3D printer connected!");
 			TFPPrinter *printer = weakSelf.printer;
 			if(!error) {
 				TFLog(@"Connected to printer %@ with firmware version %@.", printer.serialNumber, printer.firmwareVersion);

--- a/microprint/TFPPrintJob.m
+++ b/microprint/TFPPrintJob.m
@@ -64,9 +64,9 @@ static const uint16_t lineNumberWrapAround = 100; // UINT16_MAX
 - (void)sendGCode:(TFPGCode*)code {
 	__weak __typeof__(self) weakSelf = self;
 	
-	if(self.parameters.verbose) {
+//	if(self.parameters.verbose) {
 		TFLog(@"Sending %@", code);
-	}
+//	}
 	
 	uint64_t sendTime = TFNanosecondTime();
 	self.pendingRequestCount++;

--- a/microprint/TFPPrinterManager.m
+++ b/microprint/TFPPrinterManager.m
@@ -13,8 +13,8 @@
 #import "ORSSerialPortManager.h"
 
 
-static const uint16_t M3DMicroUSBVendorID = 0x03EB;
-static const uint16_t M3DMicroUSBProductID = 0x2404;
+//static const uint16_t M3DMicroUSBVendorID = 0x03EB;
+//static const uint16_t M3DMicroUSBProductID = 0x2404;
 
 
 @interface TFPPrinterManager ()
@@ -35,10 +35,11 @@ static const uint16_t M3DMicroUSBProductID = 0x2404;
 	if(!(self = [super init])) return nil;
 	
 	self.printers = [[[ORSSerialPortManager sharedSerialPortManager].availablePorts tf_selectWithBlock:^BOOL(ORSSerialPort *port) {
-		uint16_t vendorID, productID;
-		if([port getUSBVendorID:&vendorID productID:&productID]) {
-			return vendorID == M3DMicroUSBVendorID && productID == M3DMicroUSBProductID;
-		}else{
+
+        if([port.name hasPrefix: @"usbmodem"]) {
+            printf("Found Modem POrt: %s\n",[port.name UTF8String]);
+            return YES;
+		} else {
 			return NO;
 		}
 	}] tf_mapWithBlock:^TFPPrinter*(ORSSerialPort *serialPort) {


### PR DESCRIPTION
The code for trying to find US vendor ID's didn't work, couldn't find USBInterface. So I used a path matcher method instead. This seems to be the more standard way of matching for USB serial devices as the vendor code's all tend to be generic anyway.

Fixed several concurrency problems, you must set state BEFORE initiating something that affects that state asynchronously eg set the call back then call the thing that will call the call back when it's done.

The delegate for the serial framework wasn't being set in the right place so none of the call backs were working to trigger the state changes as responses came back.

Cleaned up the initialize code to be able to handle getting "wait", "e1" and "B004" messages. These needed either the M115 to be re-sent or a "Q" and the M115 to be resent. Ugly for now but I wanted to see the head move on the printer. And move it did. Now working on how you slice for this thing and have it stick.
